### PR TITLE
update termbox-go dependency

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -30,7 +30,7 @@
   branch = "master"
   name = "github.com/nsf/termbox-go"
   packages = ["."]
-  revision = "88b7b944be8bc8d8ec6195fca97c5869ba20f99d"
+  revision = "e2050e41c8847748ec5288741c0b19a8cb26d084"
 
 [solve-meta]
   analyzer-name = "dep"


### PR DESCRIPTION
This updates the `termbox-go` dependency to the current head of master. It fixes a [bug](https://github.com/nsf/termbox-go/issues/185) in termbox-go caused by ncurses 6.1 on Linux which makes `grmon` unusable. 

To reproduce the issue you can upgrade to ncurses 6.1 and run `grmon`.