### PR TITLE
feat: add secure https protocol option in arguments

### DIFF
--- a/client.go
+++ b/client.go
@@ -29,7 +29,11 @@ func getBody(url string) (bytes.Buffer, error) {
 }
 
 func poll() (routines Routines, err error) {
-	url := fmt.Sprintf("http://%s/%s/goroutine?debug=2", *hostFlag, *endpointFlag)
+	url := "http"
+	if *secureFlag {
+		url = "https"
+	}
+	url = fmt.Sprintf("%s://%s/%s/goroutine?debug=2", url, *hostFlag, *endpointFlag)
 	buf, err := getBody(url)
 	if err != nil {
 		return

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ var (
 // parse command line arguments
 var (
 	helpFlag     = flag.Bool("h", false, "display this help dialog")
+	secureFlag   = flag.Bool("s", false, "use secure https protocol (default http)")
 	hostFlag     = flag.String("host", "localhost:1234", "target host")
 	selfFlag     = flag.Bool("self", false, "monitor grmon itself")
 	endpointFlag = flag.String("endpoint", "/debug/pprof", "target path")


### PR DESCRIPTION
This will add an argument to allow users to use endpoints running on secure https protocol.